### PR TITLE
Fixed ./bin/django-ember-precompile so that it can be executed

### DIFF
--- a/bin/django-ember-precompile
+++ b/bin/django-ember-precompile
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
+
 var path = require('path');
 var fs = require('fs');
 var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
-require(lib + '/main.js');
+require(lib + '/main.js').run();


### PR DESCRIPTION
Apparently, if the shebang contains a \r it will prevent
that script from executing correctly using `/usr/bin/env node`

I pulled this down and noticed that in zsh I was getting this error:

```
env: node\r: No such file or directory
```

Here is how you can play around to see this bug in action:

```
vim bin/django-ember-precompile
:set ff
```

Then you should see something like

```
fileformat=dos
```

And try to run the command (from vim):

```
:!./bin/django-ember-precompile
```

You should see something along these lines:

```
env: node\r: No such file or directory
```

Then if you change that to unix and save the file:

```
:set ff=unix
:w
```

And run it again:

```
:!./bin/django-ember-precompile
```

You should see this:

```
USAGE: node django-ember-precompile filepath
```

SUCCESS!!!
