### PR TITLE
Windows Compatibility

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 
 Cli = (function() {
 
@@ -18,7 +19,8 @@ Cli = (function() {
 
   CliObject.prototype.generateFileObject = function() {
     var filename = this.args.slice(2);
-    var templateName = filename.toString().split('/templates/').reverse()[0].replace('.handlebars', '');
+    var templateName = filename.toString().split(path.sep + 'templates' + path.sep).reverse()[0].replace('.handlebars', '');
+    var templateName = templateName.replace(path.sep, '/');
     var template = fs.readFileSync(filename.toString(), 'utf8');
     return {'name': templateName, 'content': template};
   };

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -1,4 +1,5 @@
 require('../lib/cli');
+var path = require('path');
 
 describe("CommandLineParser Tests", function() {
 
@@ -25,31 +26,36 @@ describe("CommandLineParser Tests", function() {
 
   it("halt not invoked when valid filepath passed in", function() {
     var haltSpy = spyOn(Cli.prototype, 'haltProcessWithUsage');
-    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', 'file-system/app/templates/foo.handlebars']});
+    var tpl = path.join('file-system', 'app', 'templates', 'foo.handlebars');
+    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', tpl]});
     sut.parseCommandLineArgs();
     expect(haltSpy).not.toHaveBeenCalledWith();
   });
 
   it("returns templateName without handlebars extension when valid filepath passed in", function() {
-    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', 'file-system/app/templates/foo.handlebars']});
+    var tpl = path.join('file-system', 'app', 'templates', 'foo.handlebars');
+    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', tpl]});
     result = sut.parseCommandLineArgs();
     expect(result['name']).toEqual('foo');
   });
 
   it("returns template content when valid filepath passed in and it exists on the filesystem", function() {
-    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', 'file-system/app/templates/foo.handlebars']});
+    var tpl = path.join('file-system', 'app', 'templates', 'foo.handlebars');
+    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', tpl]});
     result = sut.parseCommandLineArgs();
     expect(result['content']).toEqual('{{outlet}}\n');
   });
 
   it("returns templateName without handlebars extension for nested template", function() {
-    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', 'file-system/app/templates/tables/index.handlebars']});
+    var tpl = path.join('file-system', 'app', 'templates', 'tables', 'index.handlebars');
+    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', tpl]});
     result = sut.parseCommandLineArgs();
     expect(result['name']).toEqual('tables/index');
   });
 
   it("returns template content for nested template", function() {
-    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', 'file-system/app/templates/tables/index.handlebars']});
+    var tpl = path.join('file-system', 'app', 'templates', 'tables', 'index.handlebars');
+    var sut = new Cli({args:['node', 'node_modules/django-ember-precompile/bin/django-ember-precompile', tpl]});
     result = sut.parseCommandLineArgs();
     expect(result['content']).toEqual('{{outlet}}\n');
   });


### PR DESCRIPTION
```
django-ember-precompile.cmd "C:\path\templates\application.handlebars"

Ember.TEMPLATES['C:\path\templates\application']=...
```

in cli.js use `path.sep` instead of hard coding `/`
